### PR TITLE
refactor(backendless-console.api): adjust dump method logic (BLS-2640)

### DIFF
--- a/libs/backendless-console-api.js
+++ b/libs/backendless-console-api.js
@@ -475,10 +475,9 @@ class Backendless {
             (table.relations || []).forEach(cleanRelation);
         }
 
-        app.tables = app.tables
-          .filter(table => !['orders_dump', 'tmp'].find(prefix => table.name.startsWith(prefix)))
-          .map(cleanTable)
+        app.tables = app.tables.filter(table => !['orders_dump', 'tmp'].find(prefix => table.name.startsWith(prefix)))
 
+        app.tables.forEach(cleanTable)
         app.roles.forEach(removeRoleId)
 
         app.services.forEach(service => {

--- a/libs/index.js
+++ b/libs/index.js
@@ -44,6 +44,7 @@ module.exports = options => {
         .then(() => (checkList[API] || checkList[API_PERMS]) && backendless.getAppServices())
         .then(() => checkList[API_PERMS] && backendless.getAppServicesRolePermissions())
         .then(() => apps = backendless.getApps())
+        .then(() => backendless.getAppCustomApiKeys(apps[0]))
         .then(() => dumpPath && BackendlessConsole.dump(apps[0], dumpPath, verboseOutput))
         .then(() => {
             if (apps.length > 1) {


### PR DESCRIPTION
- fetch apiKeys
- delete column metaInfo
- delete column dataSize for ['INT', 'TEXT'] columns only
- delete relation.metaInfo.relationIdentificationColumnId
- delete table.geoRelations

all these operations where in bl-delivery