### PR TITLE
feat(relationIdentificationColumns): resolve relationIdentificationColumns (BLS-2661)

### DIFF
--- a/libs/backendless-console-api.js
+++ b/libs/backendless-console-api.js
@@ -452,8 +452,8 @@ class Backendless {
             delete column.columnId
             delete column.metaInfo
 
-            //we have to preserve dataSize for the columns, so we delete it only for INT and TEXT as it's not needed
-            if (column.dataSize && ['INT', 'TEXT'].includes(column.dataType)) {
+            //we preserve dataSize for STRING and BOOLEAN only
+            if (column.dataSize && ['DATETIME', 'INT','TEXT', 'DATA_REF', 'JSON',' POINT', 'DOUBLE',].includes(column.dataType)) {
                 delete column.dataSize
             }
         }

--- a/libs/backendless-console-api.js
+++ b/libs/backendless-console-api.js
@@ -455,30 +455,22 @@ class Backendless {
             }
         }
 
-        const resolveRelationIdentificationColumns = tables => {
-            const columnsById = _.keyBy(_.flatMap(tables, 'columns'), 'columnId')
-
-            tables.forEach(table => {
-                const relations = table.relations || []
-
-                if (relations.length) {
-                    relations.forEach(relation => {
-                        const { relationIdentificationColumnId } = relation.metaInfo || {}
-
-                        if (relationIdentificationColumnId) {
-                            relation.metaInfo.relationIdentificationColumnName = columnsById[relationIdentificationColumnId].name
-                        }
-                    })
-                }
-            })
-        }
+        const columnsById = _.keyBy(_.flatMap(app.tables, 'columns'), 'columnId')
 
         const cleanRelation = relation => {
             delete relation.columnId
             delete relation.fromTableId
             delete relation.toTableId
 
-            relation.metaInfo && delete relation.metaInfo.relationIdentificationColumnId
+            if (relation.metaInfo) {
+                const { relationIdentificationColumnId } = relation.metaInfo
+
+                if (relationIdentificationColumnId) {
+                    relation.metaInfo.relationIdentificationColumnName = columnsById[relationIdentificationColumnId].name
+                }
+
+                delete relation.metaInfo.relationIdentificationColumnId
+            }
         }
 
         const cleanTable = table => {
@@ -491,8 +483,6 @@ class Backendless {
         }
 
         app.tables = app.tables.filter(table => !['orders_dump', 'tmp'].find(prefix => table.name.startsWith(prefix)))
-
-        resolveRelationIdentificationColumns(app.tables)
 
         app.tables.forEach(cleanTable)
         app.roles.forEach(removeRoleId)

--- a/libs/backendless-console-api.js
+++ b/libs/backendless-console-api.js
@@ -353,14 +353,12 @@ class Backendless {
     }
 
     async getAppCustomApiKeys(app) {
-        if (app.id) {
-            const appSettings = await this.getAppSettings(app.id)
+        const appSettings = await this.getAppSettings(app.id)
 
-            app.apiKeys = appSettings.apiKeys
-              .filter(key => key.deviceType === 'CUSTOM')
-              .map(key => key.name)
-              .sort()
-        }
+        app.apiKeys = appSettings.apiKeys
+          .filter(key => key.deviceType === 'CUSTOM')
+          .map(key => key.name)
+          .sort()
     }
 
     addTable(appId, name) {
@@ -452,8 +450,7 @@ class Backendless {
             delete column.columnId
             delete column.metaInfo
 
-            //we preserve dataSize for STRING and BOOLEAN only
-            if (column.dataSize && ['DATETIME', 'INT','TEXT', 'DATA_REF', 'JSON',' POINT', 'DOUBLE',].includes(column.dataType)) {
+            if (column.dataSize && !['STRING', 'FILE_REF'].includes(column.dataType)) {
                 delete column.dataSize
             }
         }

--- a/libs/sync/tables.js
+++ b/libs/sync/tables.js
@@ -87,7 +87,7 @@ const syncColumn = async (api, app, tableName, columnName, sourceColumn, targetC
                     await bulkUpdate(api, app, tableName, where, { [columnName]: sourceColumn.defaultValue })
                 }
 
-                return api.updateColumn(app.id, tableName, sourceColumn)
+                return api.updateColumn(app, tableName, sourceColumn)
             })
 
     const removeColumn = () =>


### PR DESCRIPTION
1. resolve `relationIdentificationColumnName` in `dump` method
2. resolve `relationIdentificationColumnId` based on `relationIdentificationColumnName` in logic triggered by `apply-schema`
3. fix `updateColumn` method to be able to update relative columns